### PR TITLE
Give status indicator a priority boost

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -24,7 +24,7 @@ module.exports =
       @deprecationCopStatusBarView ?= new DeprecationCopStatusBarView()
       workspaceElement = atom.views.getView(atom.workspace)
       statusBar = workspaceElement.querySelector('.status-bar')
-      statusBar?.addRightTile(item: @deprecationCopStatusBarView)
+      statusBar?.addRightTile(item: @deprecationCopStatusBarView, priority: 150)
       activatedDisposable.dispose()
 
     @commandSubscription = atom.commands.add 'atom-workspace', 'deprecation-cop:view', ->


### PR DESCRIPTION
This will put it inwards of all the standard indicators. This means the indicators that are always on the status bar will be in their typical locations whether the deprecation cop indicator is visible or not.