### PR TITLE
Access status-bar through new service API

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -19,14 +19,6 @@ module.exports =
       return unless uriToOpen is viewUri
       @deprecationCopView = createView(uri: uriToOpen)
 
-    activatedDisposable = atom.packages.onDidActivateInitialPackages =>
-      DeprecationCopStatusBarView = require './deprecation-cop-status-bar-view'
-      @deprecationCopStatusBarView ?= new DeprecationCopStatusBarView()
-      workspaceElement = atom.views.getView(atom.workspace)
-      statusBar = workspaceElement.querySelector('.status-bar')
-      statusBar?.addRightTile(item: @deprecationCopStatusBarView, priority: 150)
-      activatedDisposable.dispose()
-
     @commandSubscription = atom.commands.add 'atom-workspace', 'deprecation-cop:view', ->
       atom.workspace.open(viewUri)
 
@@ -38,3 +30,8 @@ module.exports =
     @deprecationCopView = null
     @deprecationCopStatusBarView = null
     @commandSubscription = null
+
+  consumeStatusBar: (statusBar) ->
+    DeprecationCopStatusBarView = require './deprecation-cop-status-bar-view'
+    @deprecationCopStatusBarView ?= new DeprecationCopStatusBarView()
+    statusBar.addRightTile(item: @deprecationCopStatusBarView, priority: 150)

--- a/package.json
+++ b/package.json
@@ -15,5 +15,12 @@
     "marked": "^0.3",
     "underscore-plus": "^1.0.0",
     "atom-selector-linter": "^0.2.5"
+  },
+  "consumedServices": {
+    "status-bar": {
+      "versions": {
+        "^0.58.0": "consumeStatusBar"
+      }
+    }
   }
 }

--- a/spec/deprecation-cop-status-bar-view-spec.coffee
+++ b/spec/deprecation-cop-status-bar-view-spec.coffee
@@ -14,8 +14,6 @@ describe "DeprecationCopStatusBarView", ->
     waitsForPromise -> atom.packages.activatePackage('deprecation-cop')
 
     runs ->
-      # UGH
-      atom.packages.emitter.emit 'did-activate-initial-packages'
       statusBarView = workspaceElement.querySelector('.deprecation-cop-status')
 
   afterEach ->


### PR DESCRIPTION
:warning: Depends on https://github.com/atom/status-bar/pull/51 being merged and released in Atom v0.178 :warning:

Signed-off-by: Jessica Lord <jlord@github.com>