### PR TITLE
Make status bar count deprecations as the view does

### DIFF
--- a/lib/deprecation-cop-status-bar-view.coffee
+++ b/lib/deprecation-cop-status-bar-view.coffee
@@ -36,7 +36,7 @@ class DeprecationCopStatusBarView extends View
     @deprecatedSelectorCount ?= getSelectorDeprecationsCount()
   
   getDeprecatedCallCount: ->
-    (deprecation.getStacks().length for deprecation in Grim.getDeprecations()).reduce(((a, b) -> a + b), 0);
+    Grim.getDeprecations().map((d) -> d.getStacks().length).reduce(((a, b) -> a + b), 0)
 
   updateDeprecatedSelectorCount: =>
     @deprecatedSelectorCount = null

--- a/lib/deprecation-cop-status-bar-view.coffee
+++ b/lib/deprecation-cop-status-bar-view.coffee
@@ -34,13 +34,16 @@ class DeprecationCopStatusBarView extends View
 
   getDeprecatedSelectorCount: ->
     @deprecatedSelectorCount ?= getSelectorDeprecationsCount()
+  
+  getDeprecatedCallCount: ->
+    (deprecation.getStacks().length for deprecation in Grim.getDeprecations()).reduce(((a, b) -> a + b), 0);
 
   updateDeprecatedSelectorCount: =>
     @deprecatedSelectorCount = null
     @update()
 
   update: =>
-    length = Grim.getDeprecationsLength() + @getDeprecatedSelectorCount()
+    length = @getDeprecatedCallCount() + @getDeprecatedSelectorCount()
 
     return if @lastLength == length
 

--- a/spec/deprecation-cop-status-bar-view-spec.coffee
+++ b/spec/deprecation-cop-status-bar-view-spec.coffee
@@ -35,11 +35,11 @@ describe "DeprecationCopStatusBarView", ->
     expect(statusBarView).toShow()
 
     deprecatedMethod()
-    expect(statusBarView.textContent).toBe '1'
+    expect(statusBarView.textContent).toBe '2'
     expect(statusBarView).toShow()
 
     anotherDeprecatedMethod()
-    expect(statusBarView.textContent).toBe '2'
+    expect(statusBarView.textContent).toBe '3'
     expect(statusBarView).toShow()
 
   it "increments when there are deprecated selectors", ->


### PR DESCRIPTION
This closes #37 by using the same approach for counting deprecations in the status bar as in the view (multiple deprecation call stacks [might be grouped into the same deprecation](https://github.com/atom/deprecation-cop/blob/daae43f77dcd124760d1566ad1476e979a878d5f/lib/deprecation-cop-view.coffee#L155-L162)).

Before:

![screen shot 2015-04-28 at 14 49 49](https://cloud.githubusercontent.com/assets/38924/7369883/e947c49e-edb5-11e4-9b70-7e3c03430a75.png)

After:

![screen shot 2015-04-28 at 14 49 12](https://cloud.githubusercontent.com/assets/38924/7369894/000930d2-edb6-11e4-9e27-b4609a794f9a.png)
