### PR TITLE
Lint and correctly attribute deprecations from local config files

### DIFF
--- a/lib/deprecation-cop-status-bar-view.coffee
+++ b/lib/deprecation-cop-status-bar-view.coffee
@@ -28,8 +28,8 @@ class DeprecationCopStatusBarView extends View
     userStylesheetPath = atom.styles.getUserStyleSheetPath()
     stylesChanged = (element) =>
       @updateDeprecatedSelectorCount() if element.getAttribute('source-path') is userStylesheetPath
-    atom.styles.onDidUpdateStyleElement(stylesChanged)
-    atom.styles.onDidAddStyleElement(stylesChanged)
+    @subscriptions.add atom.styles.onDidUpdateStyleElement(stylesChanged)
+    @subscriptions.add atom.styles.onDidAddStyleElement(stylesChanged)
 
   destroy: ->
     @subscriptions.dispose()

--- a/lib/deprecation-cop-status-bar-view.coffee
+++ b/lib/deprecation-cop-status-bar-view.coffee
@@ -1,4 +1,4 @@
-{CompositeDisposable, File} = require 'atom'
+{CompositeDisposable} = require 'atom'
 {$, $$, View} = require 'atom-space-pen-views'
 _ = require 'underscore-plus'
 Grim = require 'grim'
@@ -25,9 +25,11 @@ class DeprecationCopStatusBarView extends View
     @subscriptions.add atom.keymaps.onDidReloadKeymap (event) =>
       @updateDeprecatedSelectorCount() if event.path is atom.keymaps.getUserKeymapPath()
 
-    try
-      userStylesheetFile = new File(atom.styles.getUserStyleSheetPath())
-      @subscriptions.add userStylesheetFile.onDidChange @updateDeprecatedSelectorCount
+    userStylesheetPath = atom.styles.getUserStyleSheetPath()
+    stylesChanged = (element) =>
+      @updateDeprecatedSelectorCount() if element.getAttribute('source-path') is userStylesheetPath
+    atom.styles.onDidUpdateStyleElement(stylesChanged)
+    atom.styles.onDidAddStyleElement(stylesChanged)
 
   destroy: ->
     @subscriptions.dispose()

--- a/lib/deprecation-cop-status-bar-view.coffee
+++ b/lib/deprecation-cop-status-bar-view.coffee
@@ -1,4 +1,4 @@
-{CompositeDisposable} = require 'atom'
+{CompositeDisposable, File} = require 'atom'
 {$, $$, View} = require 'atom-space-pen-views'
 _ = require 'underscore-plus'
 Grim = require 'grim'
@@ -21,6 +21,15 @@ class DeprecationCopStatusBarView extends View
     @subscriptions.add atom.packages.onDidLoadPackage @updateDeprecatedSelectorCount
     @subscriptions.add atom.packages.onDidUnloadPackage @updateDeprecatedSelectorCount
     @subscriptions.add atom.packages.onDidActivatePackage @updateDeprecatedSelectorCount
+    
+    @subscriptions.add atom.keymaps.onDidReloadKeymap (event) => 
+      @updateDeprecatedSelectorCount() if event.path is atom.keymaps.getUserKeymapPath()
+    
+    try
+      userStylesheetFile = new File(atom.styles.getUserStyleSheetPath())
+      @subscriptions.add userStylesheetFile.onDidChange @updateDeprecatedSelectorCount
+    catch
+      
 
   destroy: ->
     @subscriptions.dispose()

--- a/lib/deprecation-cop-status-bar-view.coffee
+++ b/lib/deprecation-cop-status-bar-view.coffee
@@ -21,15 +21,13 @@ class DeprecationCopStatusBarView extends View
     @subscriptions.add atom.packages.onDidLoadPackage @updateDeprecatedSelectorCount
     @subscriptions.add atom.packages.onDidUnloadPackage @updateDeprecatedSelectorCount
     @subscriptions.add atom.packages.onDidActivatePackage @updateDeprecatedSelectorCount
-    
-    @subscriptions.add atom.keymaps.onDidReloadKeymap (event) => 
+
+    @subscriptions.add atom.keymaps.onDidReloadKeymap (event) =>
       @updateDeprecatedSelectorCount() if event.path is atom.keymaps.getUserKeymapPath()
-    
+
     try
       userStylesheetFile = new File(atom.styles.getUserStyleSheetPath())
       @subscriptions.add userStylesheetFile.onDidChange @updateDeprecatedSelectorCount
-    catch
-      
 
   destroy: ->
     @subscriptions.dispose()

--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -41,8 +41,7 @@ class DeprecationCopView extends ScrollView
 
     userStylesheetPath = atom.styles.getUserStyleSheetPath()
     stylesChanged = (element) =>
-      if element.getAttribute('source-path') is userStylesheetPath
-        @refreshSelectorsButton.show()
+      @refreshSelectorsButton.show() if element.getAttribute('source-path') is userStylesheetPath
     @subscriptions.add atom.styles.onDidUpdateStyleElement(stylesChanged)
     @subscriptions.add atom.styles.onDidAddStyleElement(stylesChanged)
 

--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -1,4 +1,4 @@
-{Disposable, CompositeDisposable, File} = require 'atom'
+{Disposable, CompositeDisposable} = require 'atom'
 {$, $$, ScrollView} = require 'atom-space-pen-views'
 path = require 'path'
 _ = require 'underscore-plus'
@@ -39,9 +39,12 @@ class DeprecationCopView extends ScrollView
     @subscriptions.add atom.keymaps.onDidReloadKeymap (event) =>
       @refreshSelectorsButton.show() if event.path is atom.keymaps.getUserKeymapPath()
 
-    try
-      userStylesheetFile = new File(atom.styles.getUserStyleSheetPath())
-      @subscriptions.add userStylesheetFile.onDidChange => @refreshSelectorsButton.show()
+    userStylesheetPath = atom.styles.getUserStyleSheetPath()
+    stylesChanged = (element) =>
+      if element.getAttribute('source-path') is userStylesheetPath
+        @refreshSelectorsButton.show()
+    @subscriptions.add atom.styles.onDidUpdateStyleElement(stylesChanged)
+    @subscriptions.add atom.styles.onDidAddStyleElement(stylesChanged)
 
   attached: ->
     @updateCalls()

--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -125,6 +125,9 @@ class DeprecationCopView extends ScrollView
       for packageName, packagePath of packagePaths
         relativePath = path.relative(packagePath, fileName)
         return packageName unless /^\.\./.test(relativePath)
+      
+      return "Your local #{path.basename(fileName)} file" if atom.getUserInitScriptPath() is fileName
+      
     return
 
   createIssueUrl: (packageName, deprecation, stack) ->

--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -1,4 +1,4 @@
-{Disposable, CompositeDisposable} = require 'atom'
+{Disposable, CompositeDisposable, File} = require 'atom'
 {$, $$, ScrollView} = require 'atom-space-pen-views'
 path = require 'path'
 _ = require 'underscore-plus'
@@ -35,6 +35,15 @@ class DeprecationCopView extends ScrollView
 
     @subscriptions.add atom.packages.onDidActivatePackage (pack) =>
       @refreshSelectorsButton.show() if pack.isTheme()
+    
+    @subscriptions.add atom.keymaps.onDidReloadKeymap (event) => 
+      @refreshSelectorsButton.show() if event.path is atom.keymaps.getUserKeymapPath()
+    
+    try
+      userStylesheetFile = new File(atom.styles.getUserStyleSheetPath())
+      @subscriptions.add userStylesheetFile.onDidChange => @refreshSelectorsButton.show()
+    catch
+      
 
   attached: ->
     @updateCalls()

--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -215,9 +215,10 @@ class DeprecationCopView extends ScrollView
                 @a class: 'source-url', href: path.join(deprecations[0].packagePath, sourcePath), sourcePath
                 @ul class: 'list', =>
                   for deprecation in deprecations
-                    @li class: 'list-item', =>
+                    @li class: 'list-item deprecation-detail', =>
                       @span class: 'text-warning icon icon-alert'
-                      @span class: 'list-item deprecation-message', deprecation.message
+                      @div class: 'list-item deprecation-message', =>
+                        @raw marked(deprecation.message)
 
                       @div class: 'btn-toolbar', =>
                         if url = self.createSelectorIssueUrl(packageName, deprecation, sourcePath)

--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -35,15 +35,13 @@ class DeprecationCopView extends ScrollView
 
     @subscriptions.add atom.packages.onDidActivatePackage (pack) =>
       @refreshSelectorsButton.show() if pack.isTheme()
-    
-    @subscriptions.add atom.keymaps.onDidReloadKeymap (event) => 
+
+    @subscriptions.add atom.keymaps.onDidReloadKeymap (event) =>
       @refreshSelectorsButton.show() if event.path is atom.keymaps.getUserKeymapPath()
-    
+
     try
       userStylesheetFile = new File(atom.styles.getUserStyleSheetPath())
       @subscriptions.add userStylesheetFile.onDidChange => @refreshSelectorsButton.show()
-    catch
-      
 
   attached: ->
     @updateCalls()
@@ -134,9 +132,9 @@ class DeprecationCopView extends ScrollView
       for packageName, packagePath of packagePaths
         relativePath = path.relative(packagePath, fileName)
         return packageName unless /^\.\./.test(relativePath)
-      
+
       return "Your local #{path.basename(fileName)} file" if atom.getUserInitScriptPath() is fileName
-      
+
     return
 
   createIssueUrl: (packageName, deprecation, stack) ->

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -26,11 +26,6 @@ exports.getSelectorDeprecations = ->
   
   if fs.isFileSync(userStyleSheetPath)
     userStyleSheet = fs.readFileSync(userStyleSheetPath, 'utf8')
-    linter.checkSyntaxStylesheet(userStyleSheet, {
-      packageName: "your local #{path.basename(userStyleSheetPath)} file"
-      packagePath: ""
-      sourcePath: userStyleSheetPath
-    })
     linter.checkUIStylesheet(userStyleSheet, {
       packageName: "your local #{path.basename(userStyleSheetPath)} file"
       packagePath: ""

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -8,7 +8,7 @@ exports.getSelectorDeprecations = ->
   
   userKeymapPath = atom.keymaps.getUserKeymapPath()
   
-  if fs.existsSync(userKeymapPath)
+  if fs.isFileSync(userKeymapPath)
     linter.checkKeymap(CSON.readFileSync(atom.keymaps.getUserKeymapPath()), {
       packageName: "your local #{path.basename(userKeymapPath)} file",
       packagePath: "",
@@ -17,7 +17,7 @@ exports.getSelectorDeprecations = ->
     
   userStyleSheetPath = atom.styles.getUserStyleSheetPath()
   
-  if fs.existsSync(userStyleSheetPath)
+  if fs.isFileSync(userStyleSheetPath)
     userStyleSheet = fs.readFileSync(atom.styles.getUserStyleSheetPath(), 'utf8')
     linter.checkSyntaxStylesheet(userStyleSheet, {
       packageName: "your local #{path.basename(userStyleSheetPath)} file",

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -1,8 +1,35 @@
 SelectorLinter = require 'atom-selector-linter'
+CSON = require 'season'
+fs = require 'fs-plus'
 
 exports.getSelectorDeprecations = ->
   linter = new SelectorLinter(maxPerPackage: 50)
   linter.checkPackage(pkg) for pkg in atom.packages.getLoadedPackages()
+  
+  userKeymapPath = atom.keymaps.getUserKeymapPath()
+  
+  if fs.existsSync(userKeymapPath)
+    linter.checkKeymap(CSON.readFileSync(atom.keymaps.getUserKeymapPath()), {
+      packageName: "your local #{path.basename(userKeymapPath)} file",
+      packagePath: "",
+      sourcePath: userKeymapPath
+    })
+    
+  userStyleSheetPath = atom.styles.getUserStyleSheetPath()
+  
+  if fs.existsSync(userStyleSheetPath)
+    userStyleSheet = fs.readFileSync(atom.styles.getUserStyleSheetPath(), 'utf8')
+    linter.checkSyntaxStylesheet(userStyleSheet, {
+      packageName: "your local #{path.basename(userStyleSheetPath)} file",
+      packagePath: "",
+      sourcePath: userStyleSheetPath
+    })
+    linter.checkUIStylesheet(userStyleSheet, {
+      packageName: "your local #{path.basename(userStyleSheetPath)} file",
+      packagePath: "",
+      sourcePath: userStyleSheetPath
+    })
+  
   linter.getDeprecations()
 
 exports.getSelectorDeprecationsCount = ->

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -10,8 +10,8 @@ exports.getSelectorDeprecations = ->
   
   if fs.isFileSync(userKeymapPath)
     linter.checkKeymap(CSON.readFileSync(atom.keymaps.getUserKeymapPath()), {
-      packageName: "your local #{path.basename(userKeymapPath)} file",
-      packagePath: "",
+      packageName: "your local #{path.basename(userKeymapPath)} file"
+      packagePath: ""
       sourcePath: userKeymapPath
     })
     
@@ -20,13 +20,13 @@ exports.getSelectorDeprecations = ->
   if fs.isFileSync(userStyleSheetPath)
     userStyleSheet = fs.readFileSync(atom.styles.getUserStyleSheetPath(), 'utf8')
     linter.checkSyntaxStylesheet(userStyleSheet, {
-      packageName: "your local #{path.basename(userStyleSheetPath)} file",
-      packagePath: "",
+      packageName: "your local #{path.basename(userStyleSheetPath)} file"
+      packagePath: ""
       sourcePath: userStyleSheetPath
     })
     linter.checkUIStylesheet(userStyleSheet, {
-      packageName: "your local #{path.basename(userStyleSheetPath)} file",
-      packagePath: "",
+      packageName: "your local #{path.basename(userStyleSheetPath)} file"
+      packagePath: ""
       sourcePath: userStyleSheetPath
     })
   

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -21,7 +21,6 @@ exports.getSelectorDeprecations = ->
         sourcePath: userKeymapPath
       })
       
-    
   userStyleSheetPath = atom.styles.getUserStyleSheetPath()
   
   if fs.isFileSync(userStyleSheetPath)

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -25,7 +25,7 @@ exports.getSelectorDeprecations = ->
   userStyleSheetPath = atom.styles.getUserStyleSheetPath()
   
   if fs.isFileSync(userStyleSheetPath)
-    userStyleSheet = fs.readFileSync(atom.styles.getUserStyleSheetPath(), 'utf8')
+    userStyleSheet = fs.readFileSync(userStyleSheetPath, 'utf8')
     linter.checkSyntaxStylesheet(userStyleSheet, {
       packageName: "your local #{path.basename(userStyleSheetPath)} file"
       packagePath: ""

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -10,12 +10,10 @@ exports.getSelectorDeprecations = ->
   
   if fs.isFileSync(userKeymapPath)
     try
-      userKeymapCson = CSON.readFileSync(userKeymapPath)
-    catch error
-      console.warn("Failed to load keymap file: #{userKeymapPath}", error)
-      
-    if userKeymapCson
-      linter.checkKeymap(userKeymapCson, {
+      userKeymap = CSON.readFileSync(userKeymapPath)
+
+    if userKeymap
+      linter.checkKeymap(userKeymap, {
         packageName: "your local #{path.basename(userKeymapPath)} file"
         packagePath: ""
         sourcePath: userKeymapPath
@@ -24,12 +22,15 @@ exports.getSelectorDeprecations = ->
   userStyleSheetPath = atom.styles.getUserStyleSheetPath()
   
   if fs.isFileSync(userStyleSheetPath)
-    userStyleSheet = fs.readFileSync(userStyleSheetPath, 'utf8')
-    linter.checkUIStylesheet(userStyleSheet, {
-      packageName: "your local #{path.basename(userStyleSheetPath)} file"
-      packagePath: ""
-      sourcePath: userStyleSheetPath
-    })
+    try
+      userStyleSheet = fs.readFileSync(userStyleSheetPath, 'utf8')
+
+    if userStyleSheet
+      linter.checkUIStylesheet(userStyleSheet, {
+        packageName: "your local #{path.basename(userStyleSheetPath)} file"
+        packagePath: ""
+        sourcePath: userStyleSheetPath
+      })
   
   linter.getDeprecations()
 

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -9,11 +9,18 @@ exports.getSelectorDeprecations = ->
   userKeymapPath = atom.keymaps.getUserKeymapPath()
   
   if fs.isFileSync(userKeymapPath)
-    linter.checkKeymap(CSON.readFileSync(atom.keymaps.getUserKeymapPath()), {
-      packageName: "your local #{path.basename(userKeymapPath)} file"
-      packagePath: ""
-      sourcePath: userKeymapPath
-    })
+    try
+      userKeymapCson = CSON.readFileSync(userKeymapPath)
+    catch error
+      console.warn("Failed to load keymap file: #{userKeymapPath}", error)
+      
+    if userKeymapCson
+      linter.checkKeymap(userKeymapCson, {
+        packageName: "your local #{path.basename(userKeymapPath)} file"
+        packagePath: ""
+        sourcePath: userKeymapPath
+      })
+      
     
   userStyleSheetPath = atom.styles.getUserStyleSheetPath()
   

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -7,19 +7,12 @@ createView = (state) ->
   DeprecationCopView ?= require './deprecation-cop-view'
   new DeprecationCopView(state)
 
-if Grim.includeDeprecatedAPIs
-  atom.deserializers.add
-    name: 'DeprecationCopView'
-    deserialize: createView
-
 module.exports =
   deprecationCopView: null
   deprecationCopStatusBarView: null
   commandSubscription: null
 
   activate: ->
-    return unless Grim.includeDeprecatedAPIs
-
     atom.workspace.addOpener (uriToOpen) =>
       return unless uriToOpen is viewUri
       @deprecationCopView = createView(uri: uriToOpen)
@@ -37,8 +30,6 @@ module.exports =
     @commandSubscription = null
 
   consumeStatusBar: (statusBar) ->
-    return unless Grim.includeDeprecatedAPIs
-
     DeprecationCopStatusBarView = require './deprecation-cop-status-bar-view'
     @deprecationCopStatusBarView ?= new DeprecationCopStatusBarView()
     statusBar.addRightTile(item: @deprecationCopStatusBarView, priority: 150)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "grim": "^1.4",
     "marked": "^0.3",
     "underscore-plus": "^1.0.0",
-    "atom-selector-linter": "^0.2.7"
+    "atom-selector-linter": "^0.2.7",
+    "season": "^5.1.4"
   },
   "consumedServices": {
     "status-bar": {


### PR DESCRIPTION
This is an attempt to fix https://github.com/atom/deprecation-cop/issues/18 and also fix how deprecations from `init.coffee` are attributed.

* b0ccfe2 adds a check to see if a filename in the deprecation stack matches the init script, and sets the package name to "your local init.coffee file" if it does

* 86dcf76 adds linting for the user's local keymap and styles files, and makes deprecations from those files be attributed to "your local keymap.cson file" and "your local styles.less file"

* af79721 makes selector deprecation messages render in markdown

What do you think of this direction, @kevinsawicki? I'd still need to think about adding tests for this, but just wanted to ask if this makes sense?

Before :camera: (notice that the deprecation from init.coffee is attributed to atom core, and that the selector deprecation message is not rendered in markdown):

![screen shot 2015-05-01 at 17 12 23](https://cloud.githubusercontent.com/assets/38924/7432402/19a76ce2-f028-11e4-8cb9-c307f792c095.png)

After :camera: (notice that the init.coffee deprecation is correctly attributed, markdown rendering in selector deprecation messages, and that deprecations were found in keymap.cson and styles.less):

![screen shot 2015-05-01 at 17 10 14](https://cloud.githubusercontent.com/assets/38924/7432401/19a33230-f028-11e4-8400-35c67a226f8e.png)