### PR TITLE
Refresh deprecation cop view automatically

### DIFF
--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -39,6 +39,8 @@ class DeprecationCopView extends ScrollView
     @subscriptions.add atom.styles.onDidUpdateStyleElement(stylesChanged)
     @subscriptions.add atom.styles.onDidAddStyleElement(stylesChanged)
 
+    @debouncedUpdateCalls = _.debounce(@updateCalls, 1000)
+
   attached: ->
     @updateCalls()
     @updateSelectors()
@@ -84,7 +86,7 @@ class DeprecationCopView extends ScrollView
     uri: @getURI()
 
   handleGrimUpdated: =>
-    @updateCalls()
+    @debouncedUpdateCalls()
 
   getURI: ->
     @uri

--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -14,16 +14,10 @@ class DeprecationCopView extends ScrollView
     @div class: 'deprecation-cop pane-item native-key-bindings', tabindex: -1, =>
       @div class: 'panel', =>
         @div class: 'panel-heading', =>
-          @div class: 'btn-toolbar pull-right', =>
-            @div class: 'btn-group', =>
-              @button outlet: 'refreshCallsButton', class: 'btn refresh', 'Refresh'
           @span "Deprecated calls"
         @ul outlet: 'list', class: 'list-tree has-collapsable-children'
 
         @div class: 'panel-heading', =>
-          @div class: 'btn-toolbar pull-right', =>
-            @div class: 'btn-group', =>
-              @button outlet: 'refreshSelectorsButton', class: 'btn refresh-selectors', 'Refresh'
           @span "Deprecated selectors"
         @ul outlet: 'selectorList', class: 'selectors list-tree has-collapsable-children'
 
@@ -31,17 +25,17 @@ class DeprecationCopView extends ScrollView
     @subscriptions = new CompositeDisposable
     @subscriptions.add Grim.on 'updated', @handleGrimUpdated
     @subscriptions.add atom.packages.onDidActivateInitialPackages =>
-      @refreshSelectorsButton.show()
+      @updateSelectors()
 
     @subscriptions.add atom.packages.onDidActivatePackage (pack) =>
-      @refreshSelectorsButton.show() if pack.isTheme()
+      @updateSelectors() if pack.isTheme()
 
     @subscriptions.add atom.keymaps.onDidReloadKeymap (event) =>
-      @refreshSelectorsButton.show() if event.path is atom.keymaps.getUserKeymapPath()
+      @updateSelectors() if event.path is atom.keymaps.getUserKeymapPath()
 
     userStylesheetPath = atom.styles.getUserStyleSheetPath()
     stylesChanged = (element) =>
-      @refreshSelectorsButton.show() if element.getAttribute('source-path') is userStylesheetPath
+      @updateSelectors() if element.getAttribute('source-path') is userStylesheetPath
     @subscriptions.add atom.styles.onDidUpdateStyleElement(stylesChanged)
     @subscriptions.add atom.styles.onDidAddStyleElement(stylesChanged)
 
@@ -53,9 +47,6 @@ class DeprecationCopView extends ScrollView
   subscribeToEvents: ->
     # afterAttach is called 2x when dep cop is the active pane item on reload.
     return if @subscribedToEvents
-
-    @refreshCallsButton.on 'click', => @updateCalls()
-    @refreshSelectorsButton.on 'click', => @updateSelectors()
 
     @on 'click', '.deprecation-info', ->
       $(this).parent().toggleClass('collapsed')
@@ -93,7 +84,7 @@ class DeprecationCopView extends ScrollView
     uri: @getURI()
 
   handleGrimUpdated: =>
-    @refreshCallsButton.show()
+    @updateCalls()
 
   getURI: ->
     @uri
@@ -159,7 +150,6 @@ class DeprecationCopView extends ScrollView
     "#{repoUrl}/issues/new?title=#{encodeURI(title)}&body=#{encodeURI(body)}"
 
   updateCalls: ->
-    @refreshCallsButton.hide()
     deprecations = Grim.getDeprecations()
     deprecations.sort (a, b) -> b.getCallCount() - a.getCallCount()
     @list.empty()
@@ -208,27 +198,32 @@ class DeprecationCopView extends ScrollView
                         @a class:'stack-line-location', href: location, location
 
   updateSelectors: ->
-    @refreshSelectorsButton.hide()
     @selectorList.empty()
     self = this
 
-    for packageName, deprecationsByFile of getSelectorDeprecations()
+    deprecations = getSelectorDeprecations()
+
+    if Object.keys(deprecations).length == 0
       @selectorList.append $$ ->
-        @li class: 'deprecation list-nested-item collapsed', =>
-          @div class: 'deprecation-info list-item', =>
-            @span class: 'text-highlight', packageName
+        @li class: 'list-item', "No deprecated selectors"
+    else
+      for packageName, deprecationsByFile of deprecations
+        @selectorList.append $$ ->
+          @li class: 'deprecation list-nested-item collapsed', =>
+            @div class: 'deprecation-info list-item', =>
+              @span class: 'text-highlight', packageName
 
-          @ul class: 'list', =>
-            for sourcePath, deprecations of deprecationsByFile
-              @li class: 'list-item source-file', =>
-                @a class: 'source-url', href: path.join(deprecations[0].packagePath, sourcePath), sourcePath
-                @ul class: 'list', =>
-                  for deprecation in deprecations
-                    @li class: 'list-item deprecation-detail', =>
-                      @span class: 'text-warning icon icon-alert'
-                      @div class: 'list-item deprecation-message', =>
-                        @raw marked(deprecation.message)
+            @ul class: 'list', =>
+              for sourcePath, deprecations of deprecationsByFile
+                @li class: 'list-item source-file', =>
+                  @a class: 'source-url', href: path.join(deprecations[0].packagePath, sourcePath), sourcePath
+                  @ul class: 'list', =>
+                    for deprecation in deprecations
+                      @li class: 'list-item deprecation-detail', =>
+                        @span class: 'text-warning icon icon-alert'
+                        @div class: 'list-item deprecation-message', =>
+                          @raw marked(deprecation.message)
 
-                      @div class: 'btn-toolbar', =>
-                        if url = self.createSelectorIssueUrl(packageName, deprecation, sourcePath)
-                          @a class: 'issue-url', href: url, "Create Issue on #{packageName} repo"
+                        @div class: 'btn-toolbar', =>
+                          if url = self.createSelectorIssueUrl(packageName, deprecation, sourcePath)
+                            @a class: 'issue-url', href: url, "Create Issue on #{packageName} repo"

--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -90,7 +90,7 @@ class DeprecationCopView extends ScrollView
 
   serialize: ->
     deserializer: @constructor.name
-    uri: @getUri()
+    uri: @getURI()
 
   handleGrimUpdated: =>
     @refreshCallsButton.show()

--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -164,7 +164,7 @@ class DeprecationCopView extends ScrollView
         packageDeprecations[packageName].push {deprecation, stack}
 
     # I feel guilty about this nested code catastrophe
-    if deprecations.length == 0
+    if deprecations.length is 0
       @list.append $$ ->
         @li class: 'list-item', "No deprecated calls"
     else

--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -203,27 +203,28 @@ class DeprecationCopView extends ScrollView
 
     deprecations = getSelectorDeprecations()
 
-    if Object.keys(deprecations).length == 0
+    if Object.keys(deprecations).length is 0
       @selectorList.append $$ ->
         @li class: 'list-item', "No deprecated selectors"
-    else
-      for packageName, deprecationsByFile of deprecations
-        @selectorList.append $$ ->
-          @li class: 'deprecation list-nested-item collapsed', =>
-            @div class: 'deprecation-info list-item', =>
-              @span class: 'text-highlight', packageName
+      return
 
-            @ul class: 'list', =>
-              for sourcePath, deprecations of deprecationsByFile
-                @li class: 'list-item source-file', =>
-                  @a class: 'source-url', href: path.join(deprecations[0].packagePath, sourcePath), sourcePath
-                  @ul class: 'list', =>
-                    for deprecation in deprecations
-                      @li class: 'list-item deprecation-detail', =>
-                        @span class: 'text-warning icon icon-alert'
-                        @div class: 'list-item deprecation-message', =>
-                          @raw marked(deprecation.message)
+    for packageName, deprecationsByFile of deprecations
+      @selectorList.append $$ ->
+        @li class: 'deprecation list-nested-item collapsed', =>
+          @div class: 'deprecation-info list-item', =>
+            @span class: 'text-highlight', packageName
 
-                        @div class: 'btn-toolbar', =>
-                          if url = self.createSelectorIssueUrl(packageName, deprecation, sourcePath)
-                            @a class: 'issue-url', href: url, "Create Issue on #{packageName} repo"
+          @ul class: 'list', =>
+            for sourcePath, deprecations of deprecationsByFile
+              @li class: 'list-item source-file', =>
+                @a class: 'source-url', href: path.join(deprecations[0].packagePath, sourcePath), sourcePath
+                @ul class: 'list', =>
+                  for deprecation in deprecations
+                    @li class: 'list-item deprecation-detail', =>
+                      @span class: 'text-warning icon icon-alert'
+                      @div class: 'list-item deprecation-message', =>
+                        @raw marked(deprecation.message)
+
+                      @div class: 'btn-toolbar', =>
+                        if url = self.createSelectorIssueUrl(packageName, deprecation, sourcePath)
+                          @a class: 'issue-url', href: url, "Create Issue on #{packageName} repo"

--- a/spec/deprecation-cop-spec.coffee
+++ b/spec/deprecation-cop-spec.coffee
@@ -8,7 +8,7 @@ describe "DeprecationCop", ->
     activationPromise = atom.packages.activatePackage('deprecation-cop')
 
   describe "when the deprecation-cop:view event is triggered", ->
-    it "displayes deprecation cop pane", ->
+    it "displays deprecation cop pane", ->
       expect(atom.workspace.getActivePane().getActiveItem()).not.toExist()
 
       atom.commands.dispatch workspaceElement, 'deprecation-cop:view'

--- a/spec/deprecation-cop-status-bar-view-spec.coffee
+++ b/spec/deprecation-cop-status-bar-view-spec.coffee
@@ -65,6 +65,9 @@ describe "DeprecationCopStatusBarView", ->
     runs ->
       expect(statusBarView).toBeVisible()
       expect(statusBarView.textContent).toBe '1'
+    
+      atom.packages.deactivatePackage("theme-with-deprecated-selectors")
+      atom.packages.unloadPackage("theme-with-deprecated-selectors")
 
   it 'opens deprecation cop tab when clicked', ->
     expect(atom.workspace.getActivePane().getActiveItem()).not.toExist()

--- a/spec/deprecation-cop-view-spec.coffee
+++ b/spec/deprecation-cop-view-spec.coffee
@@ -37,7 +37,7 @@ describe "DeprecationCopView", ->
 
     pack = atom.packages.loadPackage(fakePackageDir)
     spyOn(atom.packages, 'getLoadedPackages').andReturn([pack])
-    deprecationCopView.find("button.refresh-selectors").click()
+    deprecationCopView.updateSelectors()
 
     packageItems = deprecationCopView.find("ul.selectors > li")
     expect(packageItems.length).toBe(1)
@@ -53,13 +53,22 @@ describe "DeprecationCopView", ->
     expect(packageDeprecationItems.eq(2).find("a").attr("href")).toBe(path.join(fakePackageDir, "styles", "old-stylesheet.less"))
 
     jasmine.unspy(atom.packages, 'getLoadedPackages')
+    atom.packages.unloadPackage(pack.name)
 
-  it "updates when themes with deprecated selectors are activated", ->
-    deprecationCopView.find("button.refresh-selectors").click()
-    expect(deprecationCopView.find("button.refresh-selectors")).toBeHidden()
+  it "updates automatically when themes with deprecated selectors are activated", ->
+    packageItems = deprecationCopView.find("ul.selectors > li")
+    expect(packageItems.length).toBe(1)
+    expect(packageItems.text()).toMatch /No deprecated selectors/
+    
+    fakePackageDir = path.join(__dirname, "..", "spec", "fixtures", "theme-with-deprecated-selectors")
 
     waitsForPromise ->
-      atom.packages.activatePackage(path.join(__dirname, "..", "spec", "fixtures", "theme-with-deprecated-selectors"))
+      atom.packages.activatePackage(fakePackageDir)
 
     runs ->
-      expect(deprecationCopView.find("button.refresh-selectors")).toBeVisible()
+      packageItems = deprecationCopView.find("ul.selectors > li")
+      expect(packageItems.length).toBe(1)
+      packageDeprecationItems = packageItems.eq(0).find("li.source-file")
+      expect(packageDeprecationItems.length).toBe(1)
+      expect(packageDeprecationItems.eq(0).text()).toMatch /atom-workspace/
+      expect(packageDeprecationItems.eq(0).find("a").attr("href")).toBe(path.join(fakePackageDir, "styles", "old-stylesheet.less"))


### PR DESCRIPTION
This removes the "Refresh" buttons in Deprecation cop and makes it refresh automatically, as discussed in https://github.com/atom/deprecation-cop/pull/41#issuecomment-98374221.

Here it is in action:

![dep](https://cloud.githubusercontent.com/assets/38924/7575212/63a96e7c-f833-11e4-853a-97f1a1f7b0a7.gif)

cc @kevinsawicki 