### PR TITLE
Don't use stack entries which go through node_modules/ files for determining package name

### DIFF
--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -125,7 +125,7 @@ class DeprecationCopView extends ScrollView
       return unless fileName
 
       # Continue to next stack entry if call is in node_modules
-      continue if fileName.includes(path.sep + "node_modules" + path.sep)
+      continue if fileName.includes("#{path.sep}node_modules#{path.sep}")
 
       for packageName, packagePath of packagePaths
         relativePath = path.relative(packagePath, fileName)

--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -124,6 +124,9 @@ class DeprecationCopView extends ScrollView
       # Empty when it was run from the dev console
       return unless fileName
 
+      # Continue to next stack entry if call is in node_modules
+      continue if fileName.includes(path.sep + "node_modules" + path.sep)
+
       for packageName, packagePath of packagePaths
         relativePath = path.relative(packagePath, fileName)
         return packageName unless /^\.\./.test(relativePath)

--- a/spec/deprecation-cop-view-spec.coffee
+++ b/spec/deprecation-cop-view-spec.coffee
@@ -72,3 +72,31 @@ describe "DeprecationCopView", ->
       expect(packageDeprecationItems.length).toBe(1)
       expect(packageDeprecationItems.eq(0).text()).toMatch /atom-workspace/
       expect(packageDeprecationItems.eq(0).find("a").attr("href")).toBe(path.join(fakePackageDir, "styles", "old-stylesheet.less"))
+
+  it 'skips stack entries which go through node_modules/ files when determining package name', ->
+    stack = [
+      {
+        "functionName": "function0",
+        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:55:66",
+        "fileName":  "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js",
+      }
+      {
+        "functionName": "function1",
+        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:15:16",
+        "fileName":  "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js",
+      },
+      {
+        "functionName": "function2",
+        "location": "/Users/user/.atom/packages/package2/lib/module.js:13:14",
+        "fileName":  "/Users/user/.atom/packages/package2/lib/module.js",
+      }
+    ]
+
+    packagePathsByPackageName =
+      package1: "/Users/user/.atom/packages/package1"
+      package2: "/Users/user/.atom/packages/package2"
+
+    spyOn(deprecationCopView, 'getPackagePathsByPackageName').andReturn(packagePathsByPackageName)
+
+    packageName = deprecationCopView.getPackageName(stack)
+    expect(packageName).toBe("package2")


### PR DESCRIPTION
This is an attempt to fix https://github.com/atom/deprecation-cop/issues/43 by skipping stack entries in which the call passed through a file in node_modules.

While this fixes the problem in the sense that deprecations are no longer attributed to the wrong _package_, they are still not attributed to the right package -- they're being attributed to atom core because the stack is not deep enough.

Here's how this looks now (stack depth is 5, and notice that color-picker is still in the filenames):

![screen shot 2015-05-12 at 12 26 58](https://cloud.githubusercontent.com/assets/38924/7591816/30aa0980-f8d0-11e4-8d6d-83d7e3920059.png)

And if I increase the stack depth in grim to 7 , the deprecation is correctly attributed to pdf-view:

![screen shot 2015-05-12 at 12 25 57](https://cloud.githubusercontent.com/assets/38924/7591838/56d6b04a-f8d0-11e4-92c2-996544302072.png)

Is there any other approach for fixing this or would increasing the stack depth again be the only way? Not sure if these specific deprecations are common enough to justify increasing the stack depth again, but would be great if they were reported correctly as we phase out 1.0.

Tagging @kevinsawicki and @maxbrunsfeld again, my go-to deprecation superheroes :smile: