### PR TITLE
Fix empty selectors list in deprecation cop view

### DIFF
--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -288,11 +288,11 @@ class DeprecationCopView extends ScrollView
                   @button class: 'btn check-for-update', 'Check for Update'
                   @button class: 'btn disable-package', 'data-package-name': packageName, 'Disable Package'
 
-            for sourcePath, deprecations of deprecationsByFile
+            for sourcePath, deprecationsInFile of deprecationsByFile
               @li class: 'list-item source-file', =>
-                @a class: 'source-url', href: path.join(deprecations[0].packagePath, sourcePath), sourcePath
+                @a class: 'source-url', href: path.join(deprecationsInFile[0].packagePath, sourcePath), sourcePath
                 @ul class: 'list', =>
-                  for deprecation in deprecations
+                  for deprecation in deprecationsInFile
                     @li class: 'list-item deprecation-detail', =>
                       @span class: 'text-warning icon icon-alert'
                       @div class: 'list-item deprecation-message', =>


### PR DESCRIPTION
This fixes https://github.com/atom/deprecation-cop/issues/47. As far as I can tell, the problem here was that the variable `deprecations` from the outer loop was used in the inner loop, and was getting overwritten. This problem was introduced [here](https://github.com/atom/deprecation-cop/commit/edef7e739be2f3b0266f58f04790ad6ae8883c8e#diff-6c4904ca8d901aba3f94a47ab0f091eeR204) -- previously the outer loop didn't use a `deprecations` variable, it just re-fetched the deprecations in every iteration of the loop. Really sorry for not catching this before.  

This PR fixes the problem by changing the variable's name in the inner loop so that there's no conflict. We could also use the same approach as before. This just seemed a bit cleaner.

Before:

![screen shot 2015-05-19 at 09 36 30](https://cloud.githubusercontent.com/assets/38924/7697726/941b36bc-fe0a-11e4-9f96-102444773f3c.png)

After (correctly lists deprecations in styles.less):

![screen shot 2015-05-19 at 09 12 37](https://cloud.githubusercontent.com/assets/38924/7697710/7060a25c-fe0a-11e4-8fb4-a853f2bb72a5.png)

cc @kevinsawicki for :eyes: 