### PR TITLE
Fix very slow startup caused by getSelectorDeprecationsCount() called many times

### DIFF
--- a/lib/deprecation-cop-status-bar-view.coffee
+++ b/lib/deprecation-cop-status-bar-view.coffee
@@ -16,11 +16,13 @@ class DeprecationCopStatusBarView extends View
   toolTipDisposable: null
 
   initialize: ->
+    debouncedUpdateDeprecatedSelectorCount = _.debounce(@updateDeprecatedSelectorCount, 1000)
+
     @subscriptions = new CompositeDisposable
     @subscriptions.add Grim.on 'updated', @update
-    @subscriptions.add atom.packages.onDidLoadPackage @updateDeprecatedSelectorCount
-    @subscriptions.add atom.packages.onDidUnloadPackage @updateDeprecatedSelectorCount
-    @subscriptions.add atom.packages.onDidActivatePackage @updateDeprecatedSelectorCount
+    @subscriptions.add atom.packages.onDidLoadPackage debouncedUpdateDeprecatedSelectorCount
+    @subscriptions.add atom.packages.onDidUnloadPackage debouncedUpdateDeprecatedSelectorCount
+    @subscriptions.add atom.packages.onDidActivatePackage debouncedUpdateDeprecatedSelectorCount
 
     @subscriptions.add atom.keymaps.onDidReloadKeymap (event) =>
       @updateDeprecatedSelectorCount() if event.path is atom.keymaps.getUserKeymapPath()

--- a/spec/deprecation-cop-status-bar-view-spec.coffee
+++ b/spec/deprecation-cop-status-bar-view-spec.coffee
@@ -1,11 +1,17 @@
 path = require 'path'
 Grim = require 'grim'
 DeprecationCopView = require '../lib/deprecation-cop-view'
+_ = require 'underscore-plus'
 
 describe "DeprecationCopStatusBarView", ->
   [deprecatedMethod, statusBarView, workspaceElement] = []
 
   beforeEach ->
+    # jasmine.Clock.useMock() cannot mock _.debounce
+    # http://stackoverflow.com/questions/13707047/spec-for-async-functions-using-jasmine
+    spyOn(_, 'debounce').andCallFake (func) ->
+      -> func.apply(this, arguments)
+
     jasmine.snapshotDeprecations()
 
     workspaceElement = atom.views.getView(atom.workspace)


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/400558/8255270/b0e50600-16d9-11e5-8053-ae4fba542cd2.png)

updateDeprecatedSelectorCount() enforces rescanning deprecated selectors.
This method called so many times by `atom.packages` callbacks.

This PR debouces it and *dramatically* (>=1000ms) shorten startup time!