### PR TITLE
Remove text related to deprecated APIs being removed in V1.0.

### DIFF
--- a/lib/deprecation-cop-view.coffee
+++ b/lib/deprecation-cop-view.coffee
@@ -17,11 +17,6 @@ class DeprecationCopView extends ScrollView
           @div class: 'pull-right btn-group', =>
             @button class: 'btn btn-primary check-for-update', 'Check for Updates'
 
-          @div class: 'text native-key-bindings', tabindex: -1, =>
-            @span class: 'icon icon-question'
-            @span 'Deprecated APIs will be removed when Atom 1.0 is released in June. Please update your packages. '
-            @a class: 'link', outlet: 'openBlogPost', 'Learn more\u2026'
-
         @div class: 'panel-heading', =>
           @span "Deprecated calls"
         @ul outlet: 'list', class: 'list-tree has-collapsable-children'


### PR DESCRIPTION
Now that Atom is at V1.0 we no longer need to show a warning message regarding deprecated APIs being removed in the V1.0 release.

![screen shot 2015-06-25 at 10 00 40 am](https://cloud.githubusercontent.com/assets/260614/8361434/079fbda8-1b28-11e5-8252-2bc506be9804.png)
