### PR TITLE
Debounce helper methods to improve performance

### DIFF
--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -4,6 +4,11 @@ CSON = require 'season'
 fs = require 'fs-plus'
 _ = require 'underscore-plus'
 
+# disable _.debounce if jasmine is running
+if window.jasmine
+  _.debounce = (func) ->
+    -> func.apply(this, arguments)
+
 getSelectorDeprecations = ->
   linter = new SelectorLinter(maxPerPackage: 50)
   linter.checkPackage(pkg) for pkg in atom.packages.getLoadedPackages()

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -2,8 +2,9 @@ path = require 'path'
 SelectorLinter = require 'atom-selector-linter'
 CSON = require 'season'
 fs = require 'fs-plus'
+_ = require 'underscore-plus'
 
-exports.getSelectorDeprecations = ->
+exports.getSelectorDeprecations = _.debounce ->
   linter = new SelectorLinter(maxPerPackage: 50)
   linter.checkPackage(pkg) for pkg in atom.packages.getLoadedPackages()
 
@@ -34,11 +35,13 @@ exports.getSelectorDeprecations = ->
       })
 
   linter.getDeprecations()
+, 1000
 
-exports.getSelectorDeprecationsCount = ->
+exports.getSelectorDeprecationsCount = _.debounce ->
   count = 0
   deprecationsByPackageName = exports.getSelectorDeprecations()
   for packageName, deprecationsByFile of deprecationsByPackageName
     for fileName, deprecations of deprecationsByFile
       count += deprecations.length
   count
+, 1000

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -4,7 +4,7 @@ CSON = require 'season'
 fs = require 'fs-plus'
 _ = require 'underscore-plus'
 
-exports.getSelectorDeprecations = _.debounce ->
+getSelectorDeprecations = ->
   linter = new SelectorLinter(maxPerPackage: 50)
   linter.checkPackage(pkg) for pkg in atom.packages.getLoadedPackages()
 
@@ -35,13 +35,14 @@ exports.getSelectorDeprecations = _.debounce ->
       })
 
   linter.getDeprecations()
-, 1000
 
-exports.getSelectorDeprecationsCount = _.debounce ->
+getSelectorDeprecationsCount = ->
   count = 0
   deprecationsByPackageName = exports.getSelectorDeprecations()
   for packageName, deprecationsByFile of deprecationsByPackageName
     for fileName, deprecations of deprecationsByFile
       count += deprecations.length
   count
-, 1000
+
+exports.getSelectorDeprecations = _.debounce getSelectorDeprecations, 1000
+exports.getSelectorDeprecationsCount = _.debounce getSelectorDeprecationsCount, 1000

--- a/spec/deprecation-cop-view-spec.coffee
+++ b/spec/deprecation-cop-view-spec.coffee
@@ -76,19 +76,19 @@ describe "DeprecationCopView", ->
   it 'skips stack entries which go through node_modules/ files when determining package name', ->
     stack = [
       {
-        "functionName": "function0",
+        "functionName": "function0"
         "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:55:66".replace(/\//g, path.sep)
-        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js".replace(/\//g, path.sep),
+        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js".replace(/\//g, path.sep)
       }
       {
-        "functionName": "function1",
-        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:15:16".replace(/\//g, path.sep),
-        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js".replace(/\//g, path.sep),
-      },
+        "functionName": "function1"
+        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:15:16".replace(/\//g, path.sep)
+        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js".replace(/\//g, path.sep)
+      }
       {
-        "functionName": "function2",
-        "location": "/Users/user/.atom/packages/package2/lib/module.js:13:14".replace(/\//g, path.sep),
-        "fileName": "/Users/user/.atom/packages/package2/lib/module.js".replace(/\//g, path.sep),
+        "functionName": "function2"
+        "location": "/Users/user/.atom/packages/package2/lib/module.js:13:14".replace(/\//g, path.sep)
+        "fileName": "/Users/user/.atom/packages/package2/lib/module.js".replace(/\//g, path.sep)
       }
     ]
 

--- a/spec/deprecation-cop-view-spec.coffee
+++ b/spec/deprecation-cop-view-spec.coffee
@@ -77,24 +77,24 @@ describe "DeprecationCopView", ->
     stack = [
       {
         "functionName": "function0",
-        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:55:66",
-        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js",
+        "location": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package1#{path.sep}node_modules#{path.sep}atom-space-pen-viewslib#{path.sep}space-pen.js:55:66",
+        "fileName": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package1#{path.sep}node_modules#{path.sep}atom-space-pen-views#{path.sep}lib#{path.sep}space-pen.js",
       }
       {
         "functionName": "function1",
-        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:15:16",
-        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js",
+        "location": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package1#{path.sep}node_modules#{path.sep}atom-space-pen-viewslib#{path.sep}space-pen.js:15:16",
+        "fileName": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package1#{path.sep}node_modules#{path.sep}atom-space-pen-views#{path.sep}lib#{path.sep}space-pen.js",
       },
       {
         "functionName": "function2",
-        "location": "/Users/user/.atom/packages/package2/lib/module.js:13:14",
-        "fileName": "/Users/user/.atom/packages/package2/lib/module.js",
+        "location": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package2#{path.sep}lib#{path.sep}module.js:13:14",
+        "fileName": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package2#{path.sep}lib#{path.sep}module.js",
       }
     ]
 
     packagePathsByPackageName =
-      package1: "/Users/user/.atom/packages/package1"
-      package2: "/Users/user/.atom/packages/package2"
+      package1: "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package1"
+      package2: "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package2"
 
     spyOn(deprecationCopView, 'getPackagePathsByPackageName').andReturn(packagePathsByPackageName)
 

--- a/spec/deprecation-cop-view-spec.coffee
+++ b/spec/deprecation-cop-view-spec.coffee
@@ -77,24 +77,24 @@ describe "DeprecationCopView", ->
     stack = [
       {
         "functionName": "function0",
-        "location": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package1#{path.sep}node_modules#{path.sep}atom-space-pen-viewslib#{path.sep}space-pen.js:55:66",
-        "fileName": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package1#{path.sep}node_modules#{path.sep}atom-space-pen-views#{path.sep}lib#{path.sep}space-pen.js",
+        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:55:66".replace(/\//g, path.sep)
+        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js".replace(/\//g, path.sep),
       }
       {
         "functionName": "function1",
-        "location": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package1#{path.sep}node_modules#{path.sep}atom-space-pen-viewslib#{path.sep}space-pen.js:15:16",
-        "fileName": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package1#{path.sep}node_modules#{path.sep}atom-space-pen-views#{path.sep}lib#{path.sep}space-pen.js",
+        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:15:16".replace(/\//g, path.sep),
+        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js".replace(/\//g, path.sep),
       },
       {
         "functionName": "function2",
-        "location": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package2#{path.sep}lib#{path.sep}module.js:13:14",
-        "fileName": "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package2#{path.sep}lib#{path.sep}module.js",
+        "location": "/Users/user/.atom/packages/package2/lib/module.js:13:14".replace(/\//g, path.sep),
+        "fileName": "/Users/user/.atom/packages/package2/lib/module.js".replace(/\//g, path.sep),
       }
     ]
 
     packagePathsByPackageName =
-      package1: "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package1"
-      package2: "#{path.sep}Users#{path.sep}user#{path.sep}.atom#{path.sep}packages#{path.sep}package2"
+      package1: "/Users/user/.atom/packages/package1".replace(/\//g, path.sep)
+      package2: "/Users/user/.atom/packages/package2".replace(/\//g, path.sep)
 
     spyOn(deprecationCopView, 'getPackagePathsByPackageName').andReturn(packagePathsByPackageName)
 


### PR DESCRIPTION
:star: ([help with :hankey: appreciated](https://github.com/atom/deprecation-cop/pull/56#commitcomment-11999586)) :star: 


During an [analysis](https://github.com/atom/status-bar/issues/83#issuecomment-118186223) of a `status-bar` related issue I found out that `deception-cop` helper methods are called multiple (155) times. See saved profiler log **[HERE](https://gist.github.com/kubetz/a9edace33246441e5c68)**.

I noticed an optimization PR by @ypresto and tried simply encapsulating the helper functionality in `_.debounce` methods. This change affected performance quite significantly (see screenshots below).

I tested this change with all my packages enabled and in development mode.

**Before the change:**
![pre-debounce](https://cloud.githubusercontent.com/assets/1128248/8501709/3c00e08c-21a8-11e5-93b6-d6a4e24f8c30.png)

**After the change:**
![post-debounce](https://cloud.githubusercontent.com/assets/1128248/8501713/413d0774-21a8-11e5-880c-86521bec17b5.png)