### PR TITLE
Fixed failing spec on Windows

### DIFF
--- a/spec/deprecation-cop-view-spec.coffee
+++ b/spec/deprecation-cop-view-spec.coffee
@@ -76,21 +76,26 @@ describe "DeprecationCopView", ->
   it 'skips stack entries which go through node_modules/ files when determining package name', ->
     stack = [
       {
-        "functionName": "function0",
-        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:55:66",
-        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js",
+        "functionName": "function0"
+        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:55:66"
+        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js"
       }
       {
-        "functionName": "function1",
-        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:15:16",
-        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js",
-      },
+        "functionName": "function1"
+        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:15:16"
+        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js"
+      }
       {
-        "functionName": "function2",
-        "location": "/Users/user/.atom/packages/package2/lib/module.js:13:14",
-        "fileName": "/Users/user/.atom/packages/package2/lib/module.js",
+        "functionName": "function2"
+        "location": "/Users/user/.atom/packages/package2/lib/module.js:13:14"
+        "fileName": "/Users/user/.atom/packages/package2/lib/module.js"
       }
     ]
+
+    # fix path separators on Windows
+    if process.platform is 'win32'
+      for i in [0...stack.length]
+        stack[i][property] = value.replace(/\//g, path.sep) for property, value of stack[i]
 
     packagePathsByPackageName =
       package1: "/Users/user/.atom/packages/package1"

--- a/spec/deprecation-cop-view-spec.coffee
+++ b/spec/deprecation-cop-view-spec.coffee
@@ -77,29 +77,24 @@ describe "DeprecationCopView", ->
     stack = [
       {
         "functionName": "function0"
-        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:55:66"
-        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js"
+        "location": path.normalize "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:55:66"
+        "fileName": path.normalize "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js"
       }
       {
         "functionName": "function1"
-        "location": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:15:16"
-        "fileName": "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js"
+        "location": path.normalize "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-viewslib/space-pen.js:15:16"
+        "fileName": path.normalize "/Users/user/.atom/packages/package1/node_modules/atom-space-pen-views/lib/space-pen.js"
       }
       {
         "functionName": "function2"
-        "location": "/Users/user/.atom/packages/package2/lib/module.js:13:14"
-        "fileName": "/Users/user/.atom/packages/package2/lib/module.js"
+        "location": path.normalize "/Users/user/.atom/packages/package2/lib/module.js:13:14"
+        "fileName": path.normalize "/Users/user/.atom/packages/package2/lib/module.js"
       }
     ]
 
-    # fix path separators on Windows
-    if process.platform is 'win32'
-      for i in [0...stack.length]
-        stack[i][property] = value.replace(/\//g, path.sep) for property, value of stack[i]
-
     packagePathsByPackageName =
-      package1: "/Users/user/.atom/packages/package1"
-      package2: "/Users/user/.atom/packages/package2"
+      package1: path.normalize "/Users/user/.atom/packages/package1"
+      package2: path.normalize "/Users/user/.atom/packages/package2"
 
     spyOn(deprecationCopView, 'getPackagePathsByPackageName').andReturn(packagePathsByPackageName)
 


### PR DESCRIPTION
`DeprecationCopView` spec is failing on Windows because paths are using hardcoded `/` as a separator while [the check for paths to node_modules](https://github.com/atom/deprecation-cop/blob/master/lib/deprecation-cop-view.coffee#L169) is working with `path.sep`. This is causing `package1` to be selected as an package name instead of expected `package2`.

I also removed commas from `stack` as some were missing anyway and `packagePathsByPackageName` is not using any.

I used Node's `path.normalize` that should make sure returned path is normalized for the used operating system.