### PR TITLE
Fix issue creation on Windows with long issues

### DIFF
--- a/lib/deprecation-cop-view.js
+++ b/lib/deprecation-cop-view.js
@@ -190,10 +190,14 @@ export default class DeprecationCopView {
     }
   }
 
+  encodeURI (str) {
+    return encodeURI(str).replace(/#/g, '%23').replace(/;/g, '%3B').replace(/%20/g, '+')
+  }
+
   renderSelectorIssueURLIfNeeded (packageName, issueTitle, issueBody) {
     const repoURL = this.getRepoURL(packageName)
     if (repoURL) {
-      const issueURL = `${repoURL}/issues/new?title=${encodeURI(issueTitle)}&body=${encodeURI(issueBody)}`
+      const issueURL = `${repoURL}/issues/new?title=${this.encodeURI(issueTitle)}&body=${this.encodeURI(issueBody)}`
       return (
         <div className='btn-toolbar'>
           <button
@@ -251,6 +255,7 @@ export default class DeprecationCopView {
     if (issue) {
       shell.openExternal(issue.html_url)
     } else if (process.platform === 'win32') {
+      // Windows will not launch URLs greater than ~2000 bytes so we need to shrink it
       shell.openExternal((await this.shortenURL(issueURL)) || issueURL)
     } else {
       shell.openExternal(issueURL)
@@ -284,24 +289,20 @@ export default class DeprecationCopView {
     }
   }
 
-  shortenURL (url) {
-    // Here we need to use XMLHttpRequest instead of window.fetch, because the
-    // latter doesn't expose the `Location` header, which is mandatory if we
-    // want to know what git.io responded.
-    const data = new FormData()
-    data.append('url', url)
-    return new Promise((resolve, reject) => {
-      const xhr = new XMLHttpRequest()
-      xhr.onload = () => {
-        if (xhr.status < 400 && xhr.status > 200) {
-          resolve(xhr.getResponseHeader('Location'))
-        } else {
-          resolve(null)
-        }
-      }
-      xhr.open('POST', 'https://git.io')
-      xhr.send(data)
+  async shortenURL (url) {
+    let encodedUrl = encodeURIComponent(url).substr(0, 5000) // is.gd has 5000 char limit
+    let incompletePercentEncoding = encodedUrl.indexOf('%', encodedUrl.length - 2)
+    if (incompletePercentEncoding >= 0) { // Handle an incomplete % encoding cut-off
+      encodedUrl = encodedUrl.substr(0, incompletePercentEncoding)
+    }
+
+    let result = await fetch('https://is.gd/create.php?format=simple', {
+      method: 'POST',
+      headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+      body: `url=${encodedUrl}`
     })
+
+    return result.text()
   }
 
   getRepoURL (packageName) {


### PR DESCRIPTION
Windows has problems with URL passing > 2000 chars so we shorten the URL but it was breaking on many packages with the long deprecation reports generated by the syntax highlighter CSS changes.

This fixes the issue creation on Windows:

1. Switch from git.io to is.gd to (same as the notification package)
2. Switch from XMLHttpRequest to window.fetch (same as notification package)
3. Changes encoding to be lighter e.g. using + instead of %20 to get more payload
4. Limit encoded URL length to 5000 chars (is.gd limitation)

Fixes #68