### PR TITLE
Wait for view to be added before making assertions

### DIFF
--- a/spec/deprecation-cop-spec.coffee
+++ b/spec/deprecation-cop-spec.coffee
@@ -15,8 +15,11 @@ describe "DeprecationCop", ->
       waitsForPromise ->
         activationPromise
 
-      runs ->
+      deprecationCopView = null
+      waitsFor ->
         deprecationCopView = atom.workspace.getActivePane().getActiveItem()
+
+      runs ->
         expect(deprecationCopView instanceof DeprecationCopView).toBeTruthy()
 
   describe "deactivating the package", ->

--- a/spec/deprecation-cop-view-spec.coffee
+++ b/spec/deprecation-cop-view-spec.coffee
@@ -26,9 +26,10 @@ describe "DeprecationCopView", ->
     waitsForPromise ->
       activationPromise
 
+    waitsFor -> deprecationCopView = atom.workspace.getActivePane().getActiveItem()
+
     runs ->
       jasmine.unspy(Grim, 'deprecate')
-      deprecationCopView = atom.workspace.getActivePane().getActiveItem()
 
   afterEach ->
     jasmine.restoreDeprecationsSnapshot()


### PR DESCRIPTION
This was relying on the views being added after the activation promise
was resolved. Since atom/atom#13977 adds an async db lookup to the
`open()` path, that's not enough.