### PR TITLE
Wait for open to finish before making assertion

### DIFF
--- a/spec/deprecation-cop-status-bar-view-spec.coffee
+++ b/spec/deprecation-cop-status-bar-view-spec.coffee
@@ -64,9 +64,15 @@ describe "DeprecationCopStatusBarView", ->
 
   it 'opens deprecation cop tab when clicked', ->
     expect(atom.workspace.getActivePane().getActiveItem()).not.toExist()
-    statusBarView.click()
 
-    waits 0
+    # Store the last result of calling open so we can make assertions afterwards.
+    lastOpenResult = null
+    {open} = atom.workspace
+    spyOn(atom.workspace, 'open').andCallFake (args...) ->
+      lastOpenResult = open.apply atom.workspace, args
+
+    statusBarView.click()
+    waitsForPromise -> lastOpenResult
     runs ->
       depCopView = atom.workspace.getActivePane().getActiveItem()
       expect(depCopView instanceof DeprecationCopView).toBe true

--- a/spec/deprecation-cop-status-bar-view-spec.coffee
+++ b/spec/deprecation-cop-status-bar-view-spec.coffee
@@ -65,14 +65,8 @@ describe "DeprecationCopStatusBarView", ->
   it 'opens deprecation cop tab when clicked', ->
     expect(atom.workspace.getActivePane().getActiveItem()).not.toExist()
 
-    # Store the last result of calling open so we can make assertions afterwards.
-    lastOpenResult = null
-    {open} = atom.workspace
-    spyOn(atom.workspace, 'open').andCallFake (args...) ->
-      lastOpenResult = open.apply atom.workspace, args
-
-    statusBarView.click()
-    waitsForPromise -> lastOpenResult
-    runs ->
-      depCopView = atom.workspace.getActivePane().getActiveItem()
-      expect(depCopView instanceof DeprecationCopView).toBe true
+    waitsFor (done) ->
+      atom.workspace.onDidOpen ({item}) ->
+        expect(item instanceof DeprecationCopView).toBe true
+        done()
+      statusBarView.click()


### PR DESCRIPTION
Previously, this was just relying on a 0ms wait. After this change we
actually wait until the open call completes.

This fixes the remaining test failures for atom/atom#13977